### PR TITLE
Unify Trusty64 (resolves issue #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ I'm currently retrieving Ansible from git, as well as the `dopy` module for Digi
 ```
 git clone https://github.com/jbinto/ansible-ubuntu-rails-server.git
 cd ansible-ubuntu-rails-server
+brew install python
+sudo easy_install pip
 sudo pip install -r requirements.txt
 ```
 
@@ -81,7 +83,7 @@ gem install tugboat
 tugboat authorize
 ```
 
-Edit `./vars/digitalocean.yml`. 
+Edit `./vars/digitalocean.yml`.
 
 * Note that `hostname` must be a real FQDN you own, and the DNS must be pointing to DigitalOcean.
 * You can use `tugboat` to acquire the magic numbers needed for region/image/size IDs.
@@ -142,7 +144,7 @@ Note that after the first run, `root` will no longer be able to log in. To run t
 # clang: error: unknown argument: '-mno-fused-madd' [-Wunused-command-line-argument-hard-error-in-future]
 ```
 
-Run: 
+Run:
 
 ```
 echo "ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future" >> ~/.zshrc

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,10 +4,10 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  
+
   config.vm.define :web do |web|
-    web.vm.box = "precise64"
-    web.vm.box_url = "http://files.vagrantup.com/precise64.box"
+    web.vm.box = "trusty64"
+    web.vm.box_url = "http://files.vagrantup.com/trusty64.box"
     web.vm.network :private_network, ip: "10.33.33.33"
     web.vm.network :forwarded_port, guest: 80, host: 8080
 

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -38,7 +38,7 @@
     - python-psycopg2
 
 - name: Copy valid pg_hba.conf
-  template: src=pg_hba.conf.j2 dest=/etc/postgresql/9.3/main/pg_hba.conf
+  template: src=pg_hba.conf.j2 dest=/etc/postgresql/9.4/main/pg_hba.conf
   sudo: yes
 
 - name: Restart PostgreSQL


### PR DESCRIPTION
Out of the box your repo did not work for me. I had to make some small tweaks to get the crypted paassword to generate properly (just install a few things) and then I was still getting Ansible provisioning errors. Tracked it all down and made this pull request. Should resolve the issue #2 I filed.

Also, I'd like to say that your repo has been very helpful in stitching a lot of new technologies together for me. Thought I'd contribute back!
